### PR TITLE
Open URL in the browser

### DIFF
--- a/src/searchor/__init__.py
+++ b/src/searchor/__init__.py
@@ -63,7 +63,7 @@ class Engine:
 def search(query, engine=Engine.Google, open_web=False):
     url = engine.format(query=quote(query, safe=""))
     if open_web is True:
-        open_new_tab()
+        open_new_tab(url)
     return url
 
 

--- a/src/searchor/__init__.py
+++ b/src/searchor/__init__.py
@@ -3,6 +3,7 @@ from urllib.parse import quote
 from webbrowser import open_new_tab
 from enum import Enum, unique
 
+
 @unique
 class Engine(Enum):
     Apple = "https://www.apple.com/search/{query}"
@@ -59,10 +60,13 @@ class Engine(Enum):
     Yahoo = "https://search.yahoo.com/search?p={query}"
     Yandex = "https://yandex.com/search/?text={query}"
 
-    def search(self, query, open_web=False, additional_queries:dict=None):
-        url = self.value.format(query=quote(query, safe="")) + ("?" if "?" not in self.value.split("/")[-1] else "&") + "&".join(query+"="+quote(query_val) for query, query_val in additional_queries.items())
+    def search(self, query, open_web=False, additional_queries: dict = None):
+        url = self.value.format(query=quote(query, safe=""))
         if additional_queries:
-            return url
-        return self.value.format(query=quote(query, safe=""))
+            url += ("?" if "?" not in self.value.split("/")[-1] else "&") + "&".join(
+                query + "=" + quote(query_val)
+                for query, query_val in additional_queries.items()
+            )
         if open_web is True:
             open_new_tab(url)
+        return url

--- a/src/searchor/__init__.py
+++ b/src/searchor/__init__.py
@@ -1,4 +1,5 @@
 from urllib.parse import quote
+from webbrowser import open_new_tab
 
 
 # Engines are listed in alphabetical order and the UpperCamelCase convention
@@ -59,8 +60,11 @@ class Engine:
 
 
 # search function
-def search(query, engine=Engine.Google):
-    return engine.format(query=quote(query, safe=""))
+def search(query, engine=Engine.Google, open_web=False):
+    url = engine.format(query=quote(query, safe=""))
+    if open_web is True:
+        open_new_tab()
+    return url
 
 
 # returns all the engines available


### PR DESCRIPTION
Fixes #51

## What is this Pull Request About?

This PR adds a feature using which a user can open the generated url directly in their default browser. This feature is optional (as in if someone doesn't want the url to be opened in the browser, can leave the `open_web` parameter set as `False`)

## What will this Pull Request Affect?

The affected file is `./src/__init__.py`
