### PR TITLE
added functionality to add custom search engines

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -3,5 +3,6 @@
 Searchor is dependent on a lot of different modules in Searchor's codebase. This notice links modules's licenses here that were able to be found that Searchor is dependent on.
 
 [`pyperclip`](https://github.com/asweigart/pyperclip/blob/master/LICENSE.txt)
+[`aenum`](https://github.com/ethanfurman/aenum/blob/master/aenum/LICENSE)
 
 Don't see a module's license here but you know the license URL of the module? [Submit a pull request](https://github.com/ArjunSharda/Searchor/pulls)!

--- a/examples/custom_engine.py
+++ b/examples/custom_engine.py
@@ -1,0 +1,5 @@
+from searchor import Engine
+
+Engine.new("Custom", "https://www.example.com/search?q=")
+
+print(Engine.Custom.search("Hello, World!"))

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
 
     python_requires=">=3.7, <4",
 
-    install_requires=["pyperclip"],
+    install_requires=["pyperclip", "aenum"],
     
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"

--- a/src/searchor/__init__.py
+++ b/src/searchor/__init__.py
@@ -1,6 +1,7 @@
 from urllib.parse import quote
 from webbrowser import open_new_tab
 from enum import Enum, unique
+from aenum import extend_enum
 import pyperclip
 
 
@@ -103,6 +104,9 @@ class Engine(Enum):
     Yahoo = "https://search.yahoo.com/search?p={query}"
     Yandex = "https://yandex.com/search/?text={query}"
     Youtube = "https://www.youtube.com/results?search_query={query}"
+
+    def new(engine_name, base_url):
+        extend_enum(Engine, engine_name, base_url + "{query}")
 
     def search(self, query, open_web=False, copy_url=False, additional_queries: dict = None):
         url = self.value.format(query=quote(query, safe=""))


### PR DESCRIPTION
## What is this Pull Request About?

The changes in this pull request implement functionality of adding custom search engines to the main `Engine` class. A new search engine can be added by executing `Engine.new("<ENGINE_NAME>", "<BASE_URL>")`, which allows for the use of that engine immediately after, using the same syntax and with any hardcoded engine. This work was done as part of issue https://github.com/ArjunSharda/Searchor/issues/91.

## What will this Pull Request Affect?

* New module `aenum` is imported to allow for modification of base class
* New function `new(engine_name, base_url)` that extends the base enum with the new custom engines

# Any additional information?

* Added a new example called `custom_engine.py`
* Added new entry for `aenum` module in `NOTICE.md`
* Added additional install requirement for `aenum` module in `setup.py`
