### PR TITLE
Add history command to searchor cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
 
     python_requires=">=3.7, <4",
 
-    install_requires=["pyperclip"],
+    install_requires=["pyperclip", "click"],
     
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"

--- a/src/searchor/__init__.py
+++ b/src/searchor/__init__.py
@@ -79,9 +79,7 @@ class Engine(Enum):
     Quora = "https://www.quora.com/search?q={query}"
     Reddit = "https://www.reddit.com/search/?q={query}"
     Replit = "https://replit.com/search?q={query}"
-    Samsung = (
-        "https://www.samsung.com/us/search/searchMain/?listType=g&searchTerm={query}"
-    )
+    Samsung = "https://www.samsung.com/us/search/searchMain/?listType=g&searchTerm={query}"
     Spotify = "https://open.spotify.com/search/{query}"
     StackOverflow = "https://www.stackoverflow.com/search?q={query}"
     Steam = "https://store.steampowered.com/search/?term={query}"
@@ -106,9 +104,7 @@ class Engine(Enum):
     Yandex = "https://yandex.com/search/?text={query}"
     Youtube = "https://www.youtube.com/results?search_query={query}"
 
-    def search(
-        self, query, open_web=False, copy_url=False, additional_queries: dict = None
-    ):
+    def search(self, query, open_web=False, copy_url=False, additional_queries: dict = None):
         url = self.value.format(query=quote(query, safe=""))
         if additional_queries:
             url += ("?" if "?" not in self.value.split("/")[-1] else "&") + "&".join(

--- a/src/searchor/__init__.py
+++ b/src/searchor/__init__.py
@@ -4,7 +4,7 @@ from enum import Enum, unique
 import pyperclip
 
 
-@unique 
+@unique
 class Engine(Enum):
     Accuweather = "https://www.accuweather.com/en/search-locations?query={query}"
     AlternativeTo = "https://alternativeto.net/browse/search/?q={query}"
@@ -79,7 +79,9 @@ class Engine(Enum):
     Quora = "https://www.quora.com/search?q={query}"
     Reddit = "https://www.reddit.com/search/?q={query}"
     Replit = "https://replit.com/search?q={query}"
-    Samsung = "https://www.samsung.com/us/search/searchMain/?listType=g&searchTerm={query}"
+    Samsung = (
+        "https://www.samsung.com/us/search/searchMain/?listType=g&searchTerm={query}"
+    )
     Spotify = "https://open.spotify.com/search/{query}"
     StackOverflow = "https://www.stackoverflow.com/search?q={query}"
     Steam = "https://store.steampowered.com/search/?term={query}"
@@ -104,7 +106,9 @@ class Engine(Enum):
     Yandex = "https://yandex.com/search/?text={query}"
     Youtube = "https://www.youtube.com/results?search_query={query}"
 
-    def search(self, query, open_web=False, copy_url=False, additional_queries: dict = None):
+    def search(
+        self, query, open_web=False, copy_url=False, additional_queries: dict = None
+    ):
         url = self.value.format(query=quote(query, safe=""))
         if additional_queries:
             url += ("?" if "?" not in self.value.split("/")[-1] else "&") + "&".join(
@@ -118,4 +122,3 @@ class Engine(Enum):
             pyperclip.copy(url)
 
         return url
-    

--- a/src/searchor/history.py
+++ b/src/searchor/history.py
@@ -12,7 +12,8 @@ def update(engine, query, url):
     search_data = {
            "url": url,
            "engine": engine,
-           "query": query
+           "query": query,
+           "time": str(datetime.today().strftime("%I:%M %p"))
     }
     
     if not os.path.exists(DATA_PATH): # check if data file does not exist
@@ -32,5 +33,5 @@ def clear():
 def view():
     with open(DATA_PATH, "+r") as history_file:
         history_data = json.load(history_file)        
-        for s in history_data["searches"]:
-            print(s["url"])
+        for search in history_data["searches"]:
+            print(f"{search['time']}: {search['url']}")

--- a/src/searchor/history.py
+++ b/src/searchor/history.py
@@ -1,13 +1,36 @@
 import os
+import json
 import os.path
+from datetime import datetime
 
-DATA_PATH = os.path.join(os.getenv("HOME"), ".searchor-cli", "history.json")
+DATA_PATH = os.path.join(os.getenv("HOME"), ".searchor-history.json")
+tmp = {
+          "searches":[]
+      }
 
-def update(query):
-    pass
-
+def update(engine, query, url):
+    search_data = {
+           "url": url,
+           "engine": engine,
+           "query": query
+    }
+    
+    if not os.path.exists(DATA_PATH): # check if data file does not exist
+        with open(DATA_PATH, 'w') as history_file:
+            json.dump(tmp, history_file) #create file if it does not exist
+    with open(DATA_PATH, '+r') as history_file:
+        history_data = json.load(history_file)
+        history_data["searches"].append(search_data)
+        history_file.seek(0)
+        json.dump(history_data, history_file, indent=4)
+        
 def clear():
-    pass
+    if os.path.exists(DATA_PATH):
+        with open(DATA_PATH, 'w') as history_file:
+            json.dump(tmp, history_file)
 
-def read():
-    pass
+def view():
+    with open(DATA_PATH, "+r") as history_file:
+        history_data = json.load(history_file)        
+        for s in history_data["searches"]:
+            print(s["url"])

--- a/src/searchor/history.py
+++ b/src/searchor/history.py
@@ -1,0 +1,13 @@
+import os
+import os.path
+
+DATA_PATH = os.path.join(os.getenv("HOME"), ".searchor-cli", "history.json")
+
+def update(query):
+    pass
+
+def clear():
+    pass
+
+def read():
+    pass

--- a/src/searchor/history.py
+++ b/src/searchor/history.py
@@ -4,34 +4,35 @@ import os.path
 from datetime import datetime
 
 DATA_PATH = os.path.join(os.getenv("HOME"), ".searchor-history.json")
-tmp = {
-          "searches":[]
-      }
+tmp = {"searches": []}
+
 
 def update(engine, query, url):
     search_data = {
-           "url": url,
-           "engine": engine,
-           "query": query,
-           "time": str(datetime.today().strftime("%I:%M %p"))
+        "url": url,
+        "engine": engine,
+        "query": query,
+        "time": str(datetime.today().strftime("%I:%M %p")),
     }
-    
-    if not os.path.exists(DATA_PATH): # check if data file does not exist
-        with open(DATA_PATH, 'w') as history_file:
-            json.dump(tmp, history_file) #create file if it does not exist
-    with open(DATA_PATH, '+r') as history_file:
+
+    if not os.path.exists(DATA_PATH):  # check if data file does not exist
+        with open(DATA_PATH, "w") as history_file:
+            json.dump(tmp, history_file)  # create file if it does not exist
+    with open(DATA_PATH, "+r") as history_file:
         history_data = json.load(history_file)
         history_data["searches"].append(search_data)
         history_file.seek(0)
         json.dump(history_data, history_file, indent=4)
-        
+
+
 def clear():
     if os.path.exists(DATA_PATH):
-        with open(DATA_PATH, 'w') as history_file:
+        with open(DATA_PATH, "w") as history_file:
             json.dump(tmp, history_file)
+
 
 def view():
     with open(DATA_PATH, "+r") as history_file:
-        history_data = json.load(history_file)        
+        history_data = json.load(history_file)
         for search in history_data["searches"]:
             print(f"{search['time']}: {search['url']}")

--- a/src/searchor/main.py
+++ b/src/searchor/main.py
@@ -1,8 +1,11 @@
 import click
 from searchor import Engine
 
+@click.group()
+def cli():
+    pass
 
-@click.command()
+@cli.command()
 @click.option(
     "-o",
     "--open",
@@ -21,7 +24,7 @@ from searchor import Engine
 )
 @click.argument("engine")
 @click.argument("query")
-def cli(engine, query, open, copy):
+def run(engine, query, open, copy):
     click.echo(
         eval(f"Engine.{engine}.search('{query}', copy_url={copy}, open_web={open})")
     )
@@ -30,6 +33,9 @@ def cli(engine, query, open, copy):
     if copy:
         click.echo("link copied to clipboard")
 
+@cli.command()
+def history():
+    click.echo("history command, coming soon")
 
 if __name__ == "__main__":
     cli()

--- a/src/searchor/main.py
+++ b/src/searchor/main.py
@@ -2,9 +2,11 @@ import click
 from searchor import Engine
 import searchor.history
 
+
 @click.group()
 def cli():
     pass
+
 
 @cli.command()
 @click.option(
@@ -27,15 +29,18 @@ def cli():
 @click.argument("query")
 def search(engine, query, open, copy):
     try:
-        url = eval(f"Engine.{engine}.search('{query}', copy_url={copy}, open_web={open})")
+        url = eval(
+            f"Engine.{engine}.search('{query}', copy_url={copy}, open_web={open})"
+        )
         click.echo(url)
         searchor.history.update(engine, query, url)
         if open:
             click.echo("opening browser...")
         if copy:
             click.echo("link copied to clipboard")
-    except:
-        click.echo(f"engine doesn't exist")
+    except AttributeError:
+        print("engine not recognized")
+
 
 @cli.command()
 @click.option(
@@ -51,6 +56,7 @@ def history(clear):
         searchor.history.clear()
     else:
         searchor.history.view()
+
 
 if __name__ == "__main__":
     cli()

--- a/src/searchor/main.py
+++ b/src/searchor/main.py
@@ -1,6 +1,6 @@
 import click
 from searchor import Engine
-import searchor.history as sh
+import searchor.history
 
 @click.group()
 def cli():
@@ -27,19 +27,30 @@ def cli():
 @click.argument("query")
 def search(engine, query, open, copy):
     try:
-        result = eval(f"Engine.{engine}.search('{query}', copy_url={copy}, open_web={open})")
-        click.echo(result)
+        url = eval(f"Engine.{engine}.search('{query}', copy_url={copy}, open_web={open})")
+        click.echo(url)
+        searchor.history.update(engine, query, url)
         if open:
             click.echo("opening browser...")
         if copy:
             click.echo("link copied to clipboard")
-    except AttributeError:
-        click.echo(f"{engine} is not a recognized search engine")
+    except:
+        click.echo(f"engine doesn't exist")
 
 @cli.command()
-def history():
-    click.echo("history command, coming soon")
-    click.echo(sh.DATA_PATH)
+@click.option(
+    "-c",
+    "--clear",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="clears the search history",
+)
+def history(clear):
+    if clear:
+        searchor.history.clear()
+    else:
+        searchor.history.view()
 
 if __name__ == "__main__":
     cli()

--- a/src/searchor/main.py
+++ b/src/searchor/main.py
@@ -1,5 +1,6 @@
 import click
 from searchor import Engine
+import searchor.history as sh
 
 @click.group()
 def cli():
@@ -24,18 +25,21 @@ def cli():
 )
 @click.argument("engine")
 @click.argument("query")
-def run(engine, query, open, copy):
-    click.echo(
-        eval(f"Engine.{engine}.search('{query}', copy_url={copy}, open_web={open})")
-    )
-    if open:
-        click.echo("opening browser...")
-    if copy:
-        click.echo("link copied to clipboard")
+def search(engine, query, open, copy):
+    try:
+        result = eval(f"Engine.{engine}.search('{query}', copy_url={copy}, open_web={open})")
+        click.echo(result)
+        if open:
+            click.echo("opening browser...")
+        if copy:
+            click.echo("link copied to clipboard")
+    except AttributeError:
+        click.echo(f"{engine} is not a recognized search engine")
 
 @cli.command()
 def history():
     click.echo("history command, coming soon")
+    click.echo(sh.DATA_PATH)
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
## Improvement to Searchor CLI

I have added a new feature to the CLI/CLT, which is the `history` command.
The `history` command will allow users to view all previous URLs generated from the CLI,
the command will still be improved later on, but its currently capable of the most basic functionality, which is showing searchor URL history.

To make this work I created the `history.py` file, to be used as a module in `main.py` with functions for updating, clearing and viewing history data.

The history data will be stored in JSON format, and the data file will be located in the user's HOME directory as `.searchor_history.json`.

I chose JSON because I thought it would be an easy way to store all the important aspects of URL creation that might influence how history data will be viewed, without the need for extra string processing like if it was a .txt file.

To further explain, using the JSON format, I can store the URL, engine, query, time, and date of creation for each URL generated. This would actually be useful for when I'm trying to extend the functionality of  the `history` command, Like arranging URLs according to date created, or engine used.


## What will this Pull Request Affect?
changes were made to `main.py`, I included exception handling to take care of AttributeErrors, and functions from the history module were imported to be used in their respective commands.
In setup.py I added `click` as a dependency.

feel free to test out the new features and make improvements.
