### PR TITLE
removed eval from search cli method

### DIFF
--- a/src/searchor/main.py
+++ b/src/searchor/main.py
@@ -29,9 +29,7 @@ def cli():
 @click.argument("query")
 def search(engine, query, open, copy):
     try:
-        url = eval(
-            f"Engine.{engine}.search('{query}', copy_url={copy}, open_web={open})"
-        )
+        url = Engine[engine].search(query, copy_url=copy, open_web=open)
         click.echo(url)
         searchor.history.update(engine, query, url)
         if open:


### PR DESCRIPTION
## What is this Pull Request About?

The simple change in this pull request replaces the execution of `search` method in the cli code from using `eval` to calling search on the specified engine by passing `engine` as an attribute of `Engine` class. Because enum in Python is a set of members, each being a key-value pair, the syntax for getting members is the same as passing a dictionary.

## What will this Pull Request Affect?

This pull request removes the use of `eval` in the cli code, achieving the same functionality while removing vulnerability of allowing execution of arbitrary code. 