### PR TITLE
ci: Cache pip dependencies

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,6 +26,12 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+    - uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION

## What is this Pull Request About?

<!-- Add a concise description about the motive of the pull request! -->
<!-- You can also use bullet points & some text to make key points about the pull request.  -->

To reduce CI runtime, we can cache pip dependencies using actions/cache, and using setup.py (where the dependencies are defined) as the cache key.

See https://github.com/actions/cache/blob/main/examples.md#python---pip

## What will this Pull Request Affect?
<!-- Provide details on what this pull request will affect. -->
This modifies the CI to speed up its runs.

# Any additional information?
<!-- Anything else you would like to share? You can leave this blank. -->
N/A