### PR TITLE
Reduce size of docker image.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,0 @@
-.github
-ext
-src
-.gitignore
-*.md
-LICENSE
-pyproject.toml
-setup.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
-FROM python:3
-
-WORKDIR /usr/src/searchor
+FROM python:alpine
 
 ENV PIP_ROOT_USER_ACTION=ignore
-
 RUN pip install --no-cache-dir --upgrade pip \
       && pip install --no-cache-dir searchor
 
-COPY . .
-
 WORKDIR /usr/src/searchor/examples
-
-RUN python searchamazon.py
-RUN python searchbing.py
-RUN python searchduckduckgo.py
-RUN python searchgoogle.py
-RUN python searchyahoo.py
-RUN python custom_engine.py
+COPY examples .
+RUN python searchamazon.py \
+    && python searchbing.py \
+    && python searchduckduckgo.py \
+    && python searchgoogle.py \
+    && python searchyahoo.py \
+    && python custom_engine.py

--- a/README.md
+++ b/README.md
@@ -57,17 +57,15 @@ Docker
 ------
 
 Building the docker image
-```
+```sh
 $ docker build -t searchor .
 ```
 
 Running searchor on the docker container
-```
-$ docker run --rm -it searchor bash
-root@36126d096405:/usr/src/searchor/examples# python searchamazon.py
+```sh
+$ docker run --rm -it searchor sh
+/usr/src/searchor/examples # python searchamazon.py
 https://www.amazon.com/s?k=Hello%2C%20World%21
-root@36126d096405:/usr/src/searchor/examples# exit
-exit
 ```
 
 v2.4.3 Changes


### PR DESCRIPTION
## What is this Pull Request About?

Small docker images are easy to handle for the developers.

* Change `Dockerfile` to reduce docker image size(-92%).
* Remove `.docerignore`. Instead of specifying _unnecessary_ files in `.dockerignore`, we specify the _necessary_ file in `Dockerfile`.
* Update `README.md`. Use sh instead of bash.

As is:
```
$ docker image ls searchor
REPOSITORY   TAG       IMAGE ID       CREATED      SIZE      
searchor     latest    5898b20559a4   2 days ago   958MB
```
To be:
```
$ docker image ls searchor
REPOSITORY   TAG       IMAGE ID       CREATED      SIZE
searchor     latest    ecbaa632ec77   2 days ago   76.1MB
```